### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ author=Matthijs Kooijman
 email=matthijs@stdin.nl
 sentence=Parser and utilities for Dutch Smart Meters (Implementing DSMR)
 paragraph=
+category=Data Processing
 url=https://github.com/matthijskooijman/arduino-dsmr
 architectures=*
 version=0.1


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library Dsmr is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6.