### PR TITLE
Multiple changes for building on non-AVR platforms

### DIFF
--- a/examples/read/read.ino
+++ b/examples/read/read.ino
@@ -108,6 +108,10 @@ struct Printer {
 // Set up to read from the second serial port, and use D2 as the request
 // pin. On boards with only one (USB) serial port, you can also use
 // SoftwareSerial.
+#ifdef ARDUINO_ARCH_ESP32
+// Create Serial1 connected to UART 1
+HardwareSerial Serial1(1);
+#endif
 P1Reader reader(&Serial1, 2);
 
 unsigned long last;

--- a/src/dsmr/crc16.h
+++ b/src/dsmr/crc16.h
@@ -1,0 +1,102 @@
+/* CRC compatibility, adapted from the Teensy 3 core at:
+   https://github.com/PaulStoffregen/cores/tree/master/teensy3
+   which was in turn adapted by Paul Stoffregen from the C-only comments here:
+   http://svn.savannah.nongnu.org/viewvc/trunk/avr-libc/include/util/crc16.h?revision=933&root=avr-libc&view=markup */
+
+/* Copyright (c) 2002, 2003, 2004  Marek Michalkiewicz
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of the copyright holders nor the names of
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE. */
+
+#ifndef _UTIL_CRC16_H_
+#ifdef ARDUINO_ARCH_AVR
+#include <util/crc16.h>
+#else
+#define _UTIL_CRC16_H_
+#include <stdint.h>
+
+static inline uint16_t _crc16_update(uint16_t crc, uint8_t data) __attribute__((always_inline, unused));
+static inline uint16_t _crc16_update(uint16_t crc, uint8_t data)
+{
+	unsigned int i;
+
+	crc ^= data;
+	for (i = 0; i < 8; ++i) {
+		if (crc & 1) {
+			crc = (crc >> 1) ^ 0xA001;
+		} else {
+			crc = (crc >> 1);
+		}
+	}
+	return crc;
+}
+
+static inline uint16_t _crc_xmodem_update(uint16_t crc, uint8_t data) __attribute__((always_inline, unused));
+static inline uint16_t _crc_xmodem_update(uint16_t crc, uint8_t data)
+{
+	unsigned int i;
+
+	crc = crc ^ ((uint16_t)data << 8);
+	for (i=0; i<8; i++) {
+		if (crc & 0x8000) {
+			crc = (crc << 1) ^ 0x1021;
+		} else {
+			crc <<= 1;
+		}
+	}
+	return crc;
+}
+
+static inline uint16_t _crc_ccitt_update (uint16_t crc, uint8_t data) __attribute__((always_inline, unused));
+static inline uint16_t _crc_ccitt_update (uint16_t crc, uint8_t data)
+{
+	data ^= (crc & 255);
+	data ^= data << 4;
+
+	return ((((uint16_t)data << 8) | (crc >> 8)) ^ (uint8_t)(data >> 4) 
+		^ ((uint16_t)data << 3));
+}
+
+static inline uint8_t _crc_ibutton_update(uint8_t crc, uint8_t data) __attribute__((always_inline, unused));
+static inline uint8_t _crc_ibutton_update(uint8_t crc, uint8_t data)
+{
+	unsigned int i;
+
+	crc = crc ^ data;
+	for (i = 0; i < 8; i++) {
+		if (crc & 0x01) {
+			crc = (crc >> 1) ^ 0x8C;
+		} else {
+			crc >>= 1;
+		}
+	}
+	return crc;
+}
+
+#endif
+#endif

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -172,7 +172,7 @@ const uint8_t SLAVE_MBUS_ID = 4;
     value_t fieldname; \
     bool fieldname ## _present = false; \
     static constexpr ObisId id = obis; \
-    static constexpr char name_progmem[] PROGMEM = #fieldname; \
+    static constexpr char name_progmem[] DSMR_PROGMEM = #fieldname; \
     static constexpr const __FlashStringHelper *name = reinterpret_cast<const __FlashStringHelper*>(&name_progmem); \
     value_t& val() { return fieldname; } \
     bool& present() { return fieldname ## _present; } \

--- a/src/dsmr/parser.h
+++ b/src/dsmr/parser.h
@@ -31,7 +31,7 @@
 #ifndef DSMR_INCLUDE_PARSER_H
 #define DSMR_INCLUDE_PARSER_H
 
-#include <util/crc16.h>
+#include "crc16.h"
 #include "util.h"
 
 namespace dsmr {

--- a/src/dsmr/parser.h
+++ b/src/dsmr/parser.h
@@ -83,7 +83,7 @@ struct ParsedData<> {
 // Do not use F() for multiply-used strings (including strings used from
 // multiple template instantiations), that would result in multiple
 // instances of the string in the binary
-static constexpr char DUPLICATE_FIELD[] PROGMEM = "Duplicate field";
+static constexpr char DUPLICATE_FIELD[] DSMR_PROGMEM = "Duplicate field";
 
 /**
  * General case: At least one typename is passed.
@@ -156,8 +156,8 @@ struct StringParser {
 // Do not use F() for multiply-used strings (including strings used from
 // multiple template instantiations), that would result in multiple
 // instances of the string in the binary
-static constexpr char INVALID_NUMBER[] PROGMEM = "Invalid number";
-static constexpr char INVALID_UNIT[] PROGMEM = "Invalid unit";
+static constexpr char INVALID_NUMBER[] DSMR_PROGMEM = "Invalid number";
+static constexpr char INVALID_UNIT[] DSMR_PROGMEM = "Invalid unit";
 
 struct NumParser {
   static ParseResult<uint32_t> parse(size_t max_decimals, const char* unit, const char *str, const char *end) {

--- a/src/dsmr/reader.h
+++ b/src/dsmr/reader.h
@@ -33,7 +33,7 @@
 #define DSMR_INCLUDE_READER_H
 
 #include <Arduino.h>
-#include <util/crc16.h>
+#include "crc16.h"
 
 #include "parser.h"
 

--- a/src/dsmr/reader.h
+++ b/src/dsmr/reader.h
@@ -70,7 +70,7 @@ class P1Reader {
      * rate configured).
      */
     P1Reader(Stream *stream, uint8_t req_pin)
-      : stream(stream), req_pin(req_pin), once(false), state(State::DISABLED) {
+      : stream(stream), req_pin(req_pin), once(false), state(State::DISABLED_STATE) {
       pinMode(req_pin, OUTPUT);
       digitalWrite(req_pin, LOW);
     }
@@ -85,7 +85,7 @@ class P1Reader {
      */
     void enable(bool once) {
       digitalWrite(this->req_pin, HIGH);
-      this->state = State::WAITING;
+      this->state = State::WAITING_STATE;
       this->once = once;
     }
 
@@ -96,7 +96,7 @@ class P1Reader {
      */
     void disable() {
       digitalWrite(this->req_pin, LOW);
-      this->state = State::DISABLED;
+      this->state = State::DISABLED_STATE;
       if (!this->_available)
         this->buffer = "";
       // Clear any pending bytes
@@ -118,7 +118,7 @@ class P1Reader {
      */
     bool loop() {
       while(true) {
-        if (state == State::CHECKSUM) {
+        if (state == State::CHECKSUM_STATE) {
           // Let the Stream buffer the CRC bytes
           if (this->stream->available() < CrcParser::CRC_LEN)
             return false;
@@ -130,7 +130,7 @@ class P1Reader {
           ParseResult<uint16_t> crc = CrcParser::parse(buf, buf + lengthof(buf));
 
           // Prepare for next message
-          state = State::WAITING;
+          state = State::WAITING_STATE;
 
           if (!crc.err && crc.result == this->crc) {
             // Message complete, checksum correct
@@ -148,22 +148,22 @@ class P1Reader {
             return false;
 
           switch (this->state) {
-            case State::DISABLED:
+            case State::DISABLED_STATE:
               // Where did this byte come from? Just toss it
               break;
-            case State::WAITING:
+            case State::WAITING_STATE:
               if (c == '/') {
-                this->state = State::READING;
+                this->state = State::READING_STATE;
                 // Include the / in the CRC
                 this->crc = _crc16_update(0, c);
                 this->clear();
               }
               break;
-            case State::READING:
+            case State::READING_STATE:
               // Include the ! in the CRC
               this->crc = _crc16_update(this->crc, c);
               if (c == '!')
-                this->state = State::CHECKSUM;
+                this->state = State::CHECKSUM_STATE;
               else
                 buffer.concat((char)c);
 
@@ -218,10 +218,10 @@ class P1Reader {
     Stream *stream;
     uint8_t req_pin;
     enum class State : uint8_t {
-      DISABLED,
-      WAITING,
-      READING,
-      CHECKSUM,
+      DISABLED_STATE,
+      WAITING_STATE,
+      READING_STATE,
+      CHECKSUM_STATE,
     };
     bool _available;
     bool once;

--- a/src/dsmr/util.h
+++ b/src/dsmr/util.h
@@ -31,6 +31,12 @@
 #ifndef DSMR_INCLUDE_UTIL_H
 #define DSMR_INCLUDE_UTIL_H
 
+#ifdef ARDUINO_ARCH_ESP8266
+#define DSMR_PROGMEM
+#else
+#define DSMR_PROGMEM PROGMEM
+#endif
+
 #include <Arduino.h>
 
 namespace dsmr {


### PR DESCRIPTION
Tested by building the example sketches for Arduino Zero (Atmel SAMD), NodeMCU 1.0 (Espressif ESP8266), Wemos Lolin32 (Espressif ESP32).