### PR TITLE
Add Belgian Gas Meter Obis code (non-temperature converted metering)

### DIFF
--- a/src/dsmr/fields.cpp
+++ b/src/dsmr/fields.cpp
@@ -212,6 +212,10 @@ constexpr ObisId gas_delivered::id;
 constexpr char gas_delivered::name_progmem[];
 constexpr const __FlashStringHelper *gas_delivered::name;
 
+constexpr ObisId gas_delivered_non_temp_converted::id;
+constexpr char gas_delivered_non_temp_converted::name_progmem[];
+constexpr const __FlashStringHelper *gas_delivered_non_temp_converted::name;
+
 constexpr ObisId thermal_device_type::id;
 constexpr char thermal_device_type::name_progmem[];
 constexpr const __FlashStringHelper *thermal_device_type::name;

--- a/src/dsmr/fields.h
+++ b/src/dsmr/fields.h
@@ -303,6 +303,11 @@ DEFINE_FIELD(gas_valve_position, uint8_t, ObisId(0, GAS_MBUS_ID, 24, 4, 0), IntF
  * "hourly value") */
 DEFINE_FIELD(gas_delivered, TimestampedFixedValue, ObisId(0, GAS_MBUS_ID, 24, 2, 1), TimestampedFixedField, units::m3, units::dm3);
 
+/* Last 5-minute value (non-temperature converted), gas delivered to client
+ * in m3, including decimal values and capture time
+ */
+DEFINE_FIELD(gas_delivered_non_temp_converted, TimestampedFixedValue, ObisId(0, GAS_MBUS_ID, 24, 2, 3), TimestampedFixedField, units::m3, units::dm3);
+
 
 /* Device-Type */
 DEFINE_FIELD(thermal_device_type, uint16_t, ObisId(0, THERMAL_MBUS_ID, 24, 1, 0), IntField, units::none);


### PR DESCRIPTION
Gas metering differs slightly between the Dutch meters and the Flemish (Fluvius) meters. 
In NL the OBIS reference is: 0-1:24.2.1 (temperature converted)
In B the OBIS reference is: 0-1:24.2.3 (non-temperature converted)