### PR TITLE
Fix underflow in parser for decimal parsing

### DIFF
--- a/src/dsmr/parser.h
+++ b/src/dsmr/parser.h
@@ -198,7 +198,8 @@ struct NumParser {
     if (max_decimals && num_end < end && *num_end == '.') {
       ++num_end;
 
-      while(num_end < end && !strchr("*)", *num_end) && max_decimals--) {
+      while(num_end < end && !strchr("*)", *num_end) && max_decimals) {
+        --max_decimals;
         if (*num_end < '0' || *num_end > '9')
           return res.fail((const __FlashStringHelper*)INVALID_NUMBER, num_end);
         value *= 10;


### PR DESCRIPTION
In this case, the max_decimals could wrap around to UINT_MAX when the
amount of decimals after the '.' was more than 3. This would cause the
loop to keep running for ~UINT_MAX iterations, in practice hanging the
whole parser. This patch fixes this behavior and cleanly errors out if
the amount of decimals is > 3.

This will result in the following error message:

```
1-0:1.8.1(.00385.6
              ^
Missing unit
```

Example of an invalid message: `1-0:1.8.1(.00385.6`

This fixes issue #30.