### PR TITLE
Optional enable pin

### DIFF
--- a/src/dsmr/reader.h
+++ b/src/dsmr/reader.h
@@ -103,7 +103,7 @@ class P1Reader {
       if (req_pin != NO_PIN) 
         digitalWrite(this->req_pin, LOW);
       this->state = State::DISABLED_STATE;
-      if (!this->_available) 
+      if (!this->_available)
         this->buffer = "";
       // Clear any pending bytes
       while(this->stream->read() >= 0) /* nothing */;
@@ -127,7 +127,7 @@ class P1Reader {
         if (state == State::CHECKSUM_STATE) {
           // Let the Stream buffer the CRC bytes. Convert to size_t to
           // prevent unsigned vs signed comparison
-          if ((size_t)this->stream->available() < CrcParser::CRC_LEN) 
+          if ((size_t)this->stream->available() < CrcParser::CRC_LEN)
             return false;
 
           char buf[CrcParser::CRC_LEN];

--- a/src/dsmr/reader.h
+++ b/src/dsmr/reader.h
@@ -39,6 +39,8 @@
 
 namespace dsmr {
 
+#define NO_PIN 0xff
+
 /**
  * Controls the request pin on the P1 port to enable (periodic)
  * transmission of messages and reads those messages.
@@ -69,10 +71,12 @@ class P1Reader {
      * output, the Stream is assumed to be already set up (e.g. baud
      * rate configured).
      */
-    P1Reader(Stream *stream, uint8_t req_pin)
+    P1Reader(Stream *stream, uint8_t req_pin = NO_PIN)
       : stream(stream), req_pin(req_pin), once(false), state(State::DISABLED_STATE) {
-      pinMode(req_pin, OUTPUT);
-      digitalWrite(req_pin, LOW);
+      if (req_pin != NO_PIN) {
+        pinMode(req_pin, OUTPUT);
+        digitalWrite(req_pin, LOW);
+      }
     }
 
     /**
@@ -84,7 +88,8 @@ class P1Reader {
      *                 periodically.
      */
     void enable(bool once) {
-      digitalWrite(this->req_pin, HIGH);
+      if (req_pin != NO_PIN) 
+        digitalWrite(this->req_pin, HIGH);
       this->state = State::WAITING_STATE;
       this->once = once;
     }
@@ -95,9 +100,10 @@ class P1Reader {
      * clear() is called.
      */
     void disable() {
-      digitalWrite(this->req_pin, LOW);
+      if (req_pin != NO_PIN) 
+        digitalWrite(this->req_pin, LOW);
       this->state = State::DISABLED_STATE;
-      if (!this->_available)
+      if (!this->_available) 
         this->buffer = "";
       // Clear any pending bytes
       while(this->stream->read() >= 0) /* nothing */;
@@ -121,7 +127,7 @@ class P1Reader {
         if (state == State::CHECKSUM_STATE) {
           // Let the Stream buffer the CRC bytes. Convert to size_t to
           // prevent unsigned vs signed comparison
-          if ((size_t)this->stream->available() < CrcParser::CRC_LEN)
+          if ((size_t)this->stream->available() < CrcParser::CRC_LEN) 
             return false;
 
           char buf[CrcParser::CRC_LEN];
@@ -138,7 +144,7 @@ class P1Reader {
             this->_available = true;
 
             if (once)
-             this->disable();
+              this->disable();
 
             return true;
           }


### PR DESCRIPTION
Added NO_PIN define, declared as default value for `req_pin` in the constructor.
Value is 0xff which is in line with GPIO_NUM_NC which is defined for ESP boards

Use case of this is when the request pin is a multiplexed pin and the enabling/disabling of the pin is handled outside of this library